### PR TITLE
Fix issue #128

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,7 +21,7 @@ app.once('ready', () => {
     const { url, position, width, height, x, y } = data;
 
     const usingXY = x && y;
-    
+
     // electron
     const windowOptions = {
       maxHeight: height,
@@ -59,23 +59,18 @@ app.once('ready', () => {
 
         //
         // THIS MIGHT NEED WORK
-        // 
         //
-
-
-        // 
         // maybe something like this:
-        // 
+        //
         // win.webContents.on('console-message', () => {
         //  // do the shit to cloes the window like above
         // })
-        // 
+        //
         // create a specific message or something to know that shit's done, or listen to whatever
         // https://electronjs.org/docs/api/web-contents#event-console-message
-        // 
+        //
         // ipc.server.on('screenCastWindow_config', (data, socket) => {
         //   const { extraScript, closeOnEnd } = data;
-          
         //   const doScript = `${extraScript} ${closeOnEnd ? autoCloseScript : ''}`;
         //   screenCastWindow.webContents.executeJavaScript(doScript, true);
 
@@ -87,12 +82,24 @@ app.once('ready', () => {
         // ipc.server.broadcast('screenCastWindow_shown', { show: true });
 
       const autoCloseScript = `
-
+        window.setInterval(function() {
+          if (document.getElementsByClassName('WEB_PAGE_TYPE_ACCOUNT_SELECTOR').length >= 1) {
+            console.log("mmm-screencast.exited");
+          }
+        }, 1000);
       `;
+
+      screenCastWindow.webContents.on('console-message', (event, level, message, line, sourceId) => {
+        if (message === "mmm-screencast.exited") {
+           ipcInstance.server.emit(socket, 'quit');
+           app.quit();
+        }
+      });
 
       screenCastWindow.show();
       // screenCastWindow.webContents.openDevTools();
       screenCastWindow.webContents.executeJavaScript(autoPlayScript, true);
+      screenCastWindow.webContents.executeJavaScript(autoCloseScript, true);
       ipcInstance.emit(socket, 'APP_READY', {});
     });
   });

--- a/app.js
+++ b/app.js
@@ -82,9 +82,18 @@ app.once('ready', () => {
         // ipc.server.broadcast('screenCastWindow_shown', { show: true });
 
       const autoCloseScript = `
-        window.setInterval(function() {
-          if (document.getElementsByClassName('WEB_PAGE_TYPE_ACCOUNT_SELECTOR').length >= 1) {
-            console.log("mmm-screencast.exited");
+        let videoEleStop;
+
+       // consistently check the DOM for the video element
+        const interval = setInterval(() => {
+          videoEleStop = document.getElementsByTagName('video')[0];
+
+         // if the video element exists add an event listener to it and stop the interval
+          if (videoEleStop) {
+            videoEleStop.addEventListener('ended', (event) => {
+              console.log("mmm-screencast.exited");
+            });
+            clearInterval(interval);
           }
         }, 1000);
       `;

--- a/node_helper.js
+++ b/node_helper.js
@@ -7,11 +7,14 @@ module.exports = NodeHelper.create({
 	start: function() {
 		this.dialServer.mmSendSocket = (n,p) => this.sendSocketNotification(n,p);
 	},
+	stop: function() {
+		this.dialServer.stopCast();
+	},
 	socketNotificationReceived: function(notification, payload) {
 		switch (notification) {
 			case 'SET_CONFIG':
 				const { x, y, position } = payload;
-				
+
 				if (!(x && y) && !POSITIONS[position]) {
 					const message = 'There was an error with your positioning config. Please check your config.'
 					console.error(`${MODULE_NOTIFICATIONS.config_error}: ${message}`);


### PR DESCRIPTION
This fix is inspired by https://github.com/amirthapa27/MMM-Screencast

When `autoCloseScript` is called, it sends a message _(`mmm-screencast.exited`)_ to the console. If the message is received then an IPC is emitted as well as a call to the `app.quit()` method.